### PR TITLE
fix: close browser instance to prevent resource leak

### DIFF
--- a/personal_assistant/app.py
+++ b/personal_assistant/app.py
@@ -178,6 +178,8 @@ async def run_browser_automation(
         )
     except Exception as e:
         await context.bot.send_message(chat_id=chat_id, text=f"❌ Error: {e}")
+    finally:
+        await browser.close()
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Adds `finally` block to ensure `browser.close()` is always called in `run_browser_automation`
- Prevents memory leaks from unclosed browser instances in long-running bot processes

## Bug Details
The `Browser` object was created but never explicitly closed, leading to resource leaks. Each browser automation task would leave browser instances open, consuming memory and system resources.

## Fix
Added a `finally` block that ensures `await browser.close()` is called whether the agent succeeds or throws an exception.

## Test Plan
- ✅ All existing tests pass
- ✅ Verified browser cleanup happens in both success and error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)